### PR TITLE
Play iPhone audio through default speaker when no devices connected

### DIFF
--- a/src/ios/RmxAudioPlayer.m
+++ b/src/ios/RmxAudioPlayer.m
@@ -45,7 +45,7 @@ static char kPlayerItemTimeRangesContext;
     _isReplacingItems = NO;
     _isWaitingToStartPlayback = NO;
     self.rate = 1.0f;
-    self.volume = 1f;
+    self.volume = 1.0f;
     self.loop = false;
 
     [self activateAudioSession];
@@ -1283,6 +1283,9 @@ static char kPlayerItemTimeRangesContext;
     if (@available(iOS 10.0, *)) {
         options |= AVAudioSessionCategoryOptionAllowBluetoothA2DP;
     }
+
+    // If no devices are connected, play audio through the default speaker (rather than the earpiece)
+    options |= AVAudioSessionCategoryOptionDefaultToSpeaker;
 
     [avSession setCategory:AVAudioSessionCategoryPlayAndRecord withOptions:options error:&categoryError];
     if (categoryError) {


### PR DESCRIPTION
## Description

When no devices are connected, play audio through the default audio
playback speakers (for iPhone 6, 7, 8 these are located at the bottom of
the handset) rather than through the earpiece speaker, which is designed
for taking calls and is much quieter.

## Related Issue

#6 

## Motivation and Context

iPhone playback should be through the speaker designed for audio playback

## How Has This Been Tested?

Before and after test on a live device with multiple tracks

## Screenshots (if appropriate):

None appropriate (audio playback!)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
