### PR TITLE
Fix low quality audio streaming on Bluetooth devices

### DIFF
--- a/src/ios/RmxAudioPlayer.m
+++ b/src/ios/RmxAudioPlayer.m
@@ -1280,14 +1280,16 @@ static char kPlayerItemTimeRangesContext;
 {
     NSError *categoryError = nil;
     AVAudioSession* avSession = [AVAudioSession sharedInstance];
-    AVAudioSessionCategoryOptions options = AVAudioSessionCategoryOptionAllowBluetooth;
 
+    // If no devices are connected, play audio through the default speaker (rather than the earpiece).
+    AVAudioSessionCategoryOptions options = AVAudioSessionCategoryOptionDefaultToSpeaker;
+
+    // If both Bluetooth streaming options are enabled, the low quality stream is preferred; enable A2DP only.
     if (@available(iOS 10.0, *)) {
         options |= AVAudioSessionCategoryOptionAllowBluetoothA2DP;
+    } else {
+        options |= AVAudioSessionCategoryOptionAllowBluetooth;
     }
-
-    // If no devices are connected, play audio through the default speaker (rather than the earpiece)
-    options |= AVAudioSessionCategoryOptionDefaultToSpeaker;
 
     [avSession setCategory:AVAudioSessionCategoryPlayAndRecord withOptions:options error:&categoryError];
     if (categoryError) {


### PR DESCRIPTION
## Description

iOS permits two Bluetooth streaming profiles: HFP and A2DP. HFP is
intended for use with hands-free devices, typically when audio input
from the user via a microphone is required, e.g. when speaking during
a phone call. The A2DP profile is used for streaming high-quality
audio to devices that support this profile, and is typically what is
required by this plugin.

If both profiles are enabled in an audio session and available on the
target Bluetooth device, the LOWER quality HFP profile is given priority
- see the note in A2DP link below. Since there is no requirement for
audio input when playing a playlist, the A2DP profile is used whenever
possible; the HFP profile is only enabled for iOS versions older than
10.0, for which the A2DP profile is unavailable.

Links:
https://developer.apple.com/documentation/avfoundation/avaudiosessioncategoryoptions/avaudiosessioncategoryoptionallowbluetootha2dp
https://developer.apple.com/documentation/avfoundation/avaudiosessioncategoryoptions?language=objc

## Related Issue

#9 

## Motivation and Context
Streaming tracks from SoundCloud on iOS can produce a playback position of INFINITY before the track starts playing. This can cause the entire app to crash.

## How Has This Been Tested?

### Before change

Bluetooth headphones: LOW quality playback ❌
Bluetooth speakers: HIGH quality playback ✅ 
Bluetooth in-car audio: LOW quality playback ❌

### After change

Bluetooth headphones: HIGH quality playback ✅
Bluetooth speakers: HIGH quality playback ✅
Bluetooth in-car audio: HIGH quality playback ✅

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
