### PR TITLE
Allow removal of playlist items using track ID

### DIFF
--- a/src/ios/RmxAudioPlayer.m
+++ b/src/ios/RmxAudioPlayer.m
@@ -426,14 +426,14 @@ static char kPlayerItemTimeRangesContext;
 }
 
 - (BOOL) removeItemWithValues:(NSString*)trackIndex trackId:(NSString*)trackId {
-    if (trackIndex != nil
+    if ((id)trackIndex != [NSNull null]
         && [trackIndex integerValue] > 0
         && [trackIndex integerValue] < [self avQueuePlayer].itemsForPlayer.count
         ) {
         AudioTrack* item = [self avQueuePlayer].itemsForPlayer[[trackIndex integerValue]];
         [[self avQueuePlayer] removeItem:item];
         return YES;
-    } else if (trackId != nil && ![trackId isEqualToString:@""]) {
+    } else if ((id)trackId != [NSNull null] && ![trackId isEqualToString:@""]) {
         NSDictionary* result = [self findTrackById:trackId];
         NSInteger idx = [(NSNumber*)result[@"index"] integerValue];
         AudioTrack* track = result[@"track"];


### PR DESCRIPTION
Check for the type of null value (NSNull, as opposed to nil) emitted by
the AudioTrackRemoval object when the trackIndex or trackId is not
provided. This prevents a null trackIndex from being illegally converted
to an integer, and attempts to use the trackId instead.

## Description
When AudioTrackRemoval is missing either a trackIndex or trackId, that object is represented by NSNull, rather than nil. The code has been updated to check for the correct value.

## Related Issue
#12 

## Motivation and Context
Required to allow deletion of playlist track using trackId (i.e. with a null trackIndex)

## How Has This Been Tested?
Before and after test on a live device with multiple tracks

## Screenshots (if appropriate):

None appropriate, but logs before:

```
2018-08-11 19:56:57.644256+0100 GigLicker[6596:2275910] Delete track with playlist ID 34639234-317475-7235730-429476049
2018-08-11 19:56:57.646593+0100 GigLicker[6596:2275910] RmxAudioPlayer.execute=removeItem, 34639234-317475-7235730-429476049, <null>
2018-08-11 19:56:57.646691+0100 GigLicker[6596:2275910] -[NSNull integerValue]: unrecognized selector sent to instance 0x1b5b9b878
2018-08-11 19:56:57.648442+0100 GigLicker[6596:2275910] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[NSNull integerValue]: unrecognized selector sent to instance 0x1b5b9b878'
*** First throw call stack:
(0x183566d8c 0x1827205ec 0x183574098 0x18356c5c8 0x18345241c 0x104fd64c8 0x104fd3b90 0x104ff2f84 0x104e9ae54 0x104e9acb8 0x104e9c898 0x193273a2c 0x193210734 0x1932128a4 0x192f79d18 0x1931b920c 0x192f3ccfc 0x192f3f704 0x18ab9e17c 0x18ab9e3ec 0x18350f404 0x18350ec2c 0x18350c79c 0x18342cda8 0x185412020 0x18d44c758 0x104e919a0 0x182ebdfc0)
libc++abi.dylib: terminating with uncaught exception of type NSException

(lldb) frame variable
(RmxAudioPlayer *) self = 0x00000001c02c1d50
(SEL) _cmd = "removeItemWithValues:trackId:"
(NSNull *) trackIndex = 0x00000001b5b9b878 class name = NSNull
(__NSCFString *) trackId = 0x00000001c0872400 @"34639234-317475-7235730-429476049"
```

Logs after:
```
2018-08-11 19:56:57.647105+0100 GigLicker[6596:2275910] Delete track with playlist ID 34913689-8536349-131608815-189144792
2018-08-12 13:06:26.279442+0100 GigLicker[7264:2499751] RmxAudioPlayer.execute=removeItem, 34913689-8536349-131608815-189144792, <null>
2018-08-12 13:06:33.365820+0100 GigLicker[7264:2499751] playbackDuration ==> 258.6384
```
And the audio track is successfully deleted.

## Types of changes
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.