### PR TITLE
Prevent plugin from crashing when searching for non-existent trackId

### DIFF
--- a/src/ios/RmxAudioPlayer.m
+++ b/src/ios/RmxAudioPlayer.m
@@ -1234,8 +1234,9 @@ static char kPlayerItemTimeRangesContext;
         }
     }
 
+    // nil values are not permitted in NSDictionary; use NSNull instead
     return @{
-             @"track": track,
+             @"track": track ? track : [NSNull null],
              @"index": @(idx),
              };
 }


### PR DESCRIPTION
## Description

When the user searches for a track, the track and playlist index are
returned by `findTrackById`. If a suitable track is not found, use
NSNull to represent the track, as the NSDictionary returned by this
function cannot use 'nil' values.

## Related Issue
#14 

## Motivation and Context
Required to gracefully handle user / developer errors without crashing the plugin

## How Has This Been Tested?
Before and after test on a live device with multiple tracks

## Screenshots (if appropriate):

None appropriate, but logs before:

```
2018-08-15 12:56:33.947454+0100 GigLicker[9622:3395198] New playlist set
2018-08-15 12:56:33.947509+0100 GigLicker[9622:3395198] RmxAudioPlayer.execute=playTrackById, 1234567890
2018-08-15 12:56:33.948641+0100 GigLicker[9622:3395198] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[0]'
*** First throw call stack:
(0x183566d8c 0x1827205ec 0x1834ff750 0x1834380cc 0x183437f48 0x1030991a4 0x10308fd70 0x1030ae904 0x102f542bc 0x102f54120 0x102f55d9c 0x193273a2c 0x193210734 0x1932128a4 0x192f79d18 0x1931b920c 0x192f3ccfc 0x192f3f704 0x18ab9e17c 0x18ab9e3ec 0x18350f404 0x18350ec2c 0x18350c79c 0x18342cda8 0x185412020 0x18d44c758 0x102f496ec 0x182ebdfc0)
libc++abi.dylib: terminating with uncaught exception of type NSException
(lldb) frame variable
(RmxAudioPlayer *) self = 0x00000001c00d6ff0
(SEL) _cmd = "findTrackById:"
(__NSCFString *) trackId = 0x00000001c42379e0 @"1234567890"
(NSInteger) idx = -1
(AudioTrack *) track = nil
```

Logs after:
```
2018-08-15 13:19:22.497923+0100 GigLicker[9630:3403120] New playlist set
2018-08-15 13:19:22.544611+0100 GigLicker[9630:3403120] RmxAudioPlayer.execute=playTrackById, 1234567890
2018-08-15 13:19:22.586266+0100 GigLicker[9630:3403120] WARN: Track ID not found
```
And the player does not start playing - suitable since there is no corresponding track to play for this selection.

## Types of changes
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.