### PR TITLE
Remove observers when removing track from playlist

### DIFF
--- a/src/ios/RmxAudioPlayer.m
+++ b/src/ios/RmxAudioPlayer.m
@@ -431,6 +431,7 @@ static char kPlayerItemTimeRangesContext;
         && [trackIndex integerValue] < [self avQueuePlayer].itemsForPlayer.count
         ) {
         AudioTrack* item = [self avQueuePlayer].itemsForPlayer[[trackIndex integerValue]];
+        [self removeTrackObservers:item];
         [[self avQueuePlayer] removeItem:item];
         return YES;
     } else if (trackId != nil && ![trackId isEqualToString:@""]) {
@@ -440,6 +441,7 @@ static char kPlayerItemTimeRangesContext;
 
         if (idx >= 0) {
             // AudioTrack* item = [self avQueuePlayer].itemsForPlayer[idx];
+            [self removeTrackObservers:track];
             [[self avQueuePlayer] removeItem:track];
             return YES;
         } else {


### PR DESCRIPTION
## Description

Observers are removed from AudioTracks when that track is removed
from a playlist.

This prevents the plugin from crashing with the following error when
removing tracks from a playlist on iOS 10:

*** Terminating app due to uncaught exception
'NSInternalInconsistencyException', reason: 'An instance 0x123456abc of
class AudioTrack was deallocated while key value observers were still
registered with it.

## Related Issue
#17 

## Motivation and Context
iOS 10 users should be able to remove tracks without the app crashing.

Even though this issue appears to be masked in more modern operating systems (iOS 11, 12), it is a good idea to fix the underlying issue

## How Has This Been Tested?
Before and after test on a live iOS 10 device

## Screenshots (if appropriate):

None appropriate, but logs before:

```
RmxAudioPlayer.execute=removeItem, 34998414-590954-13243546-189627920, <null>
2018-10-04 20:09:12.280155 GigLicker[1690:497451] *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'An instance 0x170298ba0 of class AudioTrack was deallocated while key value observers were still registered with it. Current observation info: <NSKeyValueObservationInfo 0x17043ac80> (
<NSKeyValueObservance 0x170259ad0: Observer: 0x1700d5cb0, Key path: status, Options: <New: YES, Old: YES, Prior: NO> Context: 0x1001f4c16, Property: 0x170257790>
<NSKeyValueObservance 0x170257940: Observer: 0x1700d5cb0, Key path: duration, Options: <New: YES, Old: YES, Prior: NO> Context: 0x1001f4c17, Property: 0x170257820>
<NSKeyValueObservance 0x170259aa0: Observer: 0x1700d5cb0, Key path: loadedTimeRanges, Options: <New: YES, Old: YES, Prior: NO> Context: 0x1001f4c18, Property: 0x170257970>
)'
*** First throw call stack:
(0x1833441c0 0x181d7c55c 0x183344108 0x183d91df4 0x183229330 0x181d95fe0 0x18c8747f4 0x18c81575c 0x18c817aa0 0x18c6709b4 0x18c7f1454 0x18c639c28 0x18c63c240 0x187ab0874 0x187ab0aa0 0x1832f2278 0x1832f1bc0 0x1832ef7c0 0
libc++abi.dylib: terminating with uncaught exception of type NSException
```

Logs after:
```
RmxAudioPlayer.execute=removeItem, 34998414-590954-13243546-189627920, <null>
... // plugin continues to function as normal
```
And the track is successfully removed from the playlist.

## Types of changes
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.