### PR TITLE
Support for Android API >= 21 notification icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ Android normally will give you ~2-3 minutes of background playback before killin
 
 iOS will immediately stop playback when the app goes into the background if you do not include the `audio` `UIBackgroundMode`. iOS has an additional requirement that audio playback must never stop; when it does, the audio session will be terminated and playback cannot continue without user interaction.
 
+### Android notification icon
+To show a better notification icon in Android Lollipop (API 21) and above, create a transparent (silhouette) icon and name the file as "ic_notification.png". Then in your config.xml, inside `<platform name="android">`:
+
+```
+<resource-file src="src/assets/img/ic_notification.png" target="/app/src/main/res/drawable/ic_notification.png" />
+```
+
 ## 3. Usage
 
 Be sure to check out the examples folder, where you can find an Angular5/Ionic implementation of the Cordova plugin.

--- a/src/android/java/FakeR.java
+++ b/src/android/java/FakeR.java
@@ -26,6 +26,10 @@ public class FakeR {
 		packageName = context.getPackageName();
 	}
 
+	public Context getContext() {
+		return context;
+	}
+
 	public int getId(String group, String key) {
 		return context.getResources().getIdentifier(key, group, packageName);
 	}

--- a/src/android/java/service/MediaImageProvider.java
+++ b/src/android/java/service/MediaImageProvider.java
@@ -3,6 +3,7 @@ package com.rolamix.plugins.audioplayer.service;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.os.Build;
 import android.support.annotation.NonNull;
 
 import com.bumptech.glide.Glide;
@@ -95,10 +96,11 @@ public class MediaImageProvider implements ImageProvider<AudioTrack> {
     private int getMipmapIcon() {
         // return R.mipmap.icon; // this comes from cordova itself.
         if (notificationIconId <= 0) {
-            notificationIconId = fakeR.getId("mipmap", "icon");
-            // API 28 moves the reference to this.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                notificationIconId = fakeR.getId("drawable", "ic_notification");
+            }
             if (notificationIconId <= 0) {
-                notificationIconId = fakeR.getId("mipmap", "ic_launcher");
+                notificationIconId = fakeR.getContext().getApplicationInfo().icon; //fakeR.getId("mipmap", "icon");
             }
         }
         return notificationIconId;


### PR DESCRIPTION
## Description
The changes provide a chance to show a better notification icon in devices with Android Lollipop or above. [Example](https://i.stack.imgur.com/yESna.png)

Usually, the apps icon are a square format. The fixes provide a way to change the notification icon in Android API >= 21, rather than show the app icon (white square format). [Example](https://i.stack.imgur.com/xNqZD.png)

## How Has This Been Tested?
Tested in Motorola device with Android 8 and Samsung with Android 6.
Envs:
- Ionic 3
- Cordova Android 7.1

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
