### PR TITLE
Updated Android Support Library to Android X library

### DIFF
--- a/src/android/audio-player.gradle
+++ b/src/android/audio-player.gradle
@@ -5,6 +5,9 @@ repositories {
 }
 
 dependencies {
+  // AndroidX Annotations
+  implementation 'androidx.annotation:annotation:1.1.0' 
+
   // ExoPlayer
   implementation "com.google.android.exoplayer:exoplayer-core:2.6.1"
   implementation "com.google.android.exoplayer:exoplayer-dash:2.6.1"

--- a/src/android/java/MainApplication.java
+++ b/src/android/java/MainApplication.java
@@ -1,8 +1,8 @@
 package __PACKAGE_NAME__;
 
 import android.app.Application;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.devbrackets.android.exomedia.ExoMedia;
 import com.google.android.exoplayer2.ext.okhttp.OkHttpDataSourceFactory;

--- a/src/android/java/RmxAudioPlayer.java
+++ b/src/android/java/RmxAudioPlayer.java
@@ -1,9 +1,9 @@
 package com.rolamix.plugins.audioplayer;
 
 import android.util.Log;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.content.Context;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.apache.cordova.CordovaInterface;
 import org.json.JSONException;

--- a/src/android/java/data/AudioTrack.java
+++ b/src/android/java/data/AudioTrack.java
@@ -4,8 +4,8 @@ import com.rolamix.plugins.audioplayer.manager.PlaylistManager;
 import com.devbrackets.android.playlistcore.annotation.SupportedMediaType;
 import com.devbrackets.android.playlistcore.api.PlaylistItem;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.json.*;
 

--- a/src/android/java/manager/PlaylistManager.java
+++ b/src/android/java/manager/PlaylistManager.java
@@ -5,9 +5,9 @@ import java.util.List;
 import java.util.ArrayList;
 import android.app.Application;
 import android.util.Log;
-import android.support.annotation.FloatRange;
-import android.support.annotation.IntRange;
-import android.support.annotation.Nullable;
+import androidx.annotation.FloatRange;
+import androidx.annotation.IntRange;
+import androidx.annotation.Nullable;
 
 import com.devbrackets.android.playlistcore.api.PlaylistItem;
 import com.devbrackets.android.playlistcore.data.MediaProgress;

--- a/src/android/java/playlist/AudioApi.java
+++ b/src/android/java/playlist/AudioApi.java
@@ -6,9 +6,9 @@ import android.content.Context;
 import android.media.AudioManager;
 import android.net.Uri;
 import android.os.PowerManager;
-import android.support.annotation.FloatRange;
-import android.support.annotation.IntRange;
-import android.support.annotation.NonNull;
+import androidx.annotation.FloatRange;
+import androidx.annotation.IntRange;
+import androidx.annotation.NonNull;
 
 import com.devbrackets.android.exomedia.AudioPlayer;
 import com.devbrackets.android.playlistcore.manager.BasePlaylistManager;

--- a/src/android/java/playlist/AudioPlaylistHandler.java
+++ b/src/android/java/playlist/AudioPlaylistHandler.java
@@ -4,10 +4,10 @@ import com.rolamix.plugins.audioplayer.data.AudioTrack;
 import com.rolamix.plugins.audioplayer.manager.PlaylistManager;
 import com.rolamix.plugins.audioplayer.notification.PlaylistNotificationProvider;
 
-import android.support.annotation.Nullable;
 import android.app.Service;
 import android.content.Context;
 import android.util.Log;
+import androidx.annotation.Nullable;
 
 import com.devbrackets.android.playlistcore.api.PlaylistItem;
 import com.devbrackets.android.playlistcore.api.MediaPlayerApi;

--- a/src/android/java/service/MediaImageProvider.java
+++ b/src/android/java/service/MediaImageProvider.java
@@ -4,7 +4,7 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.os.Build;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.RequestManager;

--- a/src/android/java/service/MediaService.java
+++ b/src/android/java/service/MediaService.java
@@ -1,8 +1,8 @@
 package com.rolamix.plugins.audioplayer.service;
 
 import __PACKAGE_NAME__.MainApplication;
-import android.support.annotation.NonNull;
 import android.util.Log;
+import androidx.annotation.NonNull;
 
 import com.devbrackets.android.playlistcore.api.MediaPlayerApi;
 import com.devbrackets.android.playlistcore.components.playlisthandler.PlaylistHandler;


### PR DESCRIPTION
## Description
Updated use of support library for annotations to the androidx library. This is due to the support library no longer being maintained and the androidx library replacing it.

## Related Issue
https://github.com/Rolamix/cordova-plugin-playlist/issues/42

## Motivation and Context
This change is required due to android's maintenance of the support library stopping, which may eventually lead to them deprecating the library. This is to future proof the plugin and allow it to work with other updated plugins.

## How Has This Been Tested?
Since all it changed was the used libraries for certain function tags -- namely FloatRange, IntRange, NotNull, and Nullable -- I've tested it in my own cordova app and was able to successfully build with Android X Support.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
This would cause anyone updating to this latest version to no longer be able to use the plugin when Android X support is disabled.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
